### PR TITLE
Allow hostname for BK7238 - copied from lwip-2.1.3

### DIFF
--- a/beken378/func/lwip_intf/lwip-2.0.2/port/ethernetif.c
+++ b/beken378/func/lwip_intf/lwip-2.0.2/port/ethernetif.c
@@ -113,6 +113,14 @@ void ethernetif_input(int iface, struct pbuf *p);
  *        for this ethernetif
  */
 
+#define MY_OPENBK7231N_USE_MAC_AS_WLAN_NAME 1
+
+#if MY_OPENBK7231N_USE_MAC_AS_WLAN_NAME
+char g_customWlanName[32];
+// This will give linker errors on any non-App project...
+const char *CFG_GetOpenBekenHostName();
+
+#else
 const char wlan_name[][6] =
 {
     "wlan0\0",
@@ -120,15 +128,26 @@ const char wlan_name[][6] =
     "wlan2\0",
     "wlan3\0",
 };
+#endif
 static void low_level_init(struct netif *netif)
 {
     VIF_INF_PTR vif_entry = (VIF_INF_PTR)(netif->state);
     u8 *macptr = (u8*)&vif_entry->mac_addr;
-
 #if LWIP_NETIF_HOSTNAME
+#if MY_OPENBK7231N_USE_MAC_AS_WLAN_NAME
+	const char *tmpPtr;
+	tmpPtr = CFG_GetOpenBekenHostName();
+	if(tmpPtr != 0 && tmpPtr[0] != 0) {
+	   netif->hostname = tmpPtr;
+	} else {
+		sprintf(g_customWlanName,"OpenBK7231N_%02X%02X%02X%02X",macptr[0],macptr[1],macptr[2],macptr[3]);
+	   netif->hostname = g_customWlanName;
+	}
+#else
     /* Initialize interface hostname */
     netif->hostname = (char*)&wlan_name[vif_entry->index];
-#endif /* LWIP_NETIF_HOSTNAME */
+#endif
+#endif /* LWIP_NETIF_HOSTNAME */ 
 
 	//wifi_get_mac_address((char *)wireless_mac, type);
 


### PR DESCRIPTION
Simply copied already changed code from lwip-2.1.3 to 2.0.2 with one small change: 

moved `const char *tmpPtr;` inside the `"#if"`

Before:
```
max@max-PC:~$ nmap -sP 192.168.0.0/24 | grep 86
Nmap scan report for wlan0.fritz.box (192.168.0.86)
max@max-PC:~$ 
```


After
```
max@max-PC:~$ nmap -sP 192.168.0.0/24 | grep 86
Nmap scan report for OpenBK7238-XXXXXXXX.fritz.box (192.168.0.86)
max@max-PC:~$ 
```